### PR TITLE
Fix: Correct shortCode logic with searchParams fallback

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,112 @@
+// src/app/page.test.tsx
+import React from 'react';
+import { render } from '@testing-library/react'; // Or your preferred testing library
+import SlotPage from './page'; // The component to test
+
+// Mock dependencies
+jest.mock('@telegram-apps/sdk-react', () => ({
+  useLaunchParams: jest.fn(),
+}));
+
+// Mock next/navigation for useSearchParams
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'), // Preserve other exports
+  useSearchParams: jest.fn(),
+}));
+
+// Mock the child component to check its props
+jest.mock('./[shortCode]/page', () => ({
+  __esModule: true, // This is important for ES6 modules
+  default: jest.fn(() => <div>Mocked SlotDetailsPage</div>), // Mock component
+}));
+jest.mock('./[shortCode]/_context/ViewerContext', () => ({
+  ViewerProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+
+// Import mocked hooks/components for type safety if needed
+import { useLaunchParams } from '@telegram-apps/sdk-react';
+import { useSearchParams } from 'next/navigation'; // For typing if needed
+import SlotDetailsPage from './[shortCode]/page';
+
+describe('SlotPage', () => {
+  let mockSearchGet: jest.Mock;
+
+  beforeEach(() => {
+    // Clear mock call history before each test
+    (useLaunchParams as jest.Mock).mockClear();
+    (SlotDetailsPage as jest.Mock).mockClear();
+    
+    // Reset and re-configure useSearchParams mock for each test
+    mockSearchGet = jest.fn();
+    (useSearchParams as jest.Mock).mockReturnValue({ get: mockSearchGet });
+    (useSearchParams as jest.Mock).mockClear(); // Clear calls to useSearchParams itself
+    mockSearchGet.mockClear(); // Clear calls to the 'get' method
+  });
+
+  it('should use startParam if provided, ignoring searchParams', () => {
+    (useLaunchParams as jest.Mock).mockReturnValue({ startParam: 'fromStartParam' });
+    mockSearchGet.mockReturnValue('fromQueryShouldBeIgnored');
+    render(<SlotPage />);
+    expect(SlotDetailsPage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { shortCode: 'fromStartParam' } }),
+      expect.anything()
+    );
+    expect(mockSearchGet).not.toHaveBeenCalled(); // searchParams.get should not be called
+  });
+
+  it('should use searchParams.get("shortCode") if startParam is undefined', () => {
+    (useLaunchParams as jest.Mock).mockReturnValue({ startParam: undefined });
+    mockSearchGet.mockReturnValue('fromQuery');
+    render(<SlotPage />);
+    expect(SlotDetailsPage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { shortCode: 'fromQuery' } }),
+      expect.anything()
+    );
+    expect(mockSearchGet).toHaveBeenCalledWith('shortCode');
+  });
+
+  it('should use searchParams.get("shortCode") if startParam is an empty string', () => {
+    (useLaunchParams as jest.Mock).mockReturnValue({ startParam: '' });
+    mockSearchGet.mockReturnValue('fromQueryIfStartEmpty');
+    render(<SlotPage />);
+    expect(SlotDetailsPage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { shortCode: 'fromQueryIfStartEmpty' } }),
+      expect.anything()
+    );
+    expect(mockSearchGet).toHaveBeenCalledWith('shortCode');
+  });
+
+  it('should use "404" if startParam is undefined and searchParams.get("shortCode") is null', () => {
+    (useLaunchParams as jest.Mock).mockReturnValue({ startParam: undefined });
+    mockSearchGet.mockReturnValue(null);
+    render(<SlotPage />);
+    expect(SlotDetailsPage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { shortCode: '404' } }),
+      expect.anything()
+    );
+    expect(mockSearchGet).toHaveBeenCalledWith('shortCode');
+  });
+
+  it('should use "404" if startParam is an empty string and searchParams.get("shortCode") is an empty string', () => {
+    (useLaunchParams as jest.Mock).mockReturnValue({ startParam: '' });
+    mockSearchGet.mockReturnValue('');
+    render(<SlotPage />);
+    expect(SlotDetailsPage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { shortCode: '404' } }),
+      expect.anything()
+    );
+    expect(mockSearchGet).toHaveBeenCalledWith('shortCode');
+  });
+  
+  it('should prioritize startParam even if searchParams.get("shortCode") is also provided', () => {
+    (useLaunchParams as jest.Mock).mockReturnValue({ startParam: 'fromStartParamAgain' });
+    mockSearchGet.mockReturnValue('fromQueryShouldBeIgnored');
+    render(<SlotPage />);
+    expect(SlotDetailsPage).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { shortCode: 'fromStartParamAgain' } }),
+      expect.anything()
+    );
+    expect(mockSearchGet).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,31 @@
 'use client';
 
 import { useLaunchParams } from '@telegram-apps/sdk-react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation'; // Re-add this
 import SlotDetailsPage from './[shortCode]/page';
 import { ViewerProvider } from './[shortCode]/_context/ViewerContext';
 
 const SlotPage = () => {
   const lp = useLaunchParams();
-  const shortCode = lp.startParam;
+  const searchParams = useSearchParams(); // Re-add this
 
-  const searchParams = useSearchParams();
+  let finalShortCode: string;
+  if (lp.startParam) {
+    finalShortCode = lp.startParam;
+  } else {
+    const queryShortCode = searchParams.get('shortCode');
+    if (queryShortCode) {
+      finalShortCode = queryShortCode;
+    } else {
+      finalShortCode = '404';
+    }
+  }
 
   return (
     <ViewerProvider>
       <SlotDetailsPage
         params={{
-          shortCode: shortCode || searchParams.get('shortCode') || '',
+          shortCode: finalShortCode,
         }}
       />
     </ViewerProvider>


### PR DESCRIPTION
I've updated the `shortCode` determination logic in `src/app/page.tsx` to correctly implement the fallback behavior.

The order of precedence for `shortCode` is now:
1. `launchParams.startParam` (if present and non-empty).
2. `searchParams.get('shortCode')` (if `startParam` is not present/empty, and `searchParams.get('shortCode')` is present and non-empty).
3. Defaults to '404' if neither of the above provides a value.

This change re-introduces `useSearchParams` and updates the unit tests to cover all scenarios of this revised logic, ensuring `startParam` priority and the correct fallback to `searchParams` before defaulting to '404'.